### PR TITLE
Update ClusterSecretStore API version from v1beta1 to v1 across all configs

### DIFF
--- a/helm-config.yaml
+++ b/helm-config.yaml
@@ -5,7 +5,7 @@ namespace: *name
 environments:
   local:
     apis: &apis
-    - external-secrets.io/v1beta1/ClusterSecretStore
+    - external-secrets.io/v1/ClusterSecretStore
     - monitoring.coreos.com/v1
     - monitoring.coreos.com/v1/PodMonitor
     - monitoring.coreos.com/v1/ServiceMonitor

--- a/templates/awssm-cluster-secret-store.yaml
+++ b/templates/awssm-cluster-secret-store.yaml
@@ -1,5 +1,5 @@
-{{- if .Capabilities.APIVersions.Has "external-secrets.io/v1beta1/ClusterSecretStore" }}
-apiVersion: external-secrets.io/v1beta1
+{{- if .Capabilities.APIVersions.Has "external-secrets.io/v1/ClusterSecretStore" }}
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   annotations:

--- a/tests/awssm-cluster-secret-store_test.yaml
+++ b/tests/awssm-cluster-secret-store_test.yaml
@@ -1,7 +1,7 @@
 suite: test if the settings for the awssm-cluster-secret-store are correct
 capabilities:
   apiVersions:
-  - external-secrets.io/v1beta1/ClusterSecretStore
+  - external-secrets.io/v1/ClusterSecretStore
 release:
   name: &releaseName external-secrets
   namespace: *releaseName


### PR DESCRIPTION
This pull request updates our configuration and templates to use the newer `external-secrets.io/v1` API version for `ClusterSecretStore` instead of the deprecated `v1beta1`. This change ensures compatibility with the latest version of the External Secrets Operator and helps prevent issues with future upgrades.

**API version migration:**

* Updated the `helm-config.yaml` to reference `external-secrets.io/v1/ClusterSecretStore` instead of `external-secrets.io/v1beta1/ClusterSecretStore` for local environment APIs.
* Changed the template condition and `apiVersion` in `templates/awssm-cluster-secret-store.yaml` to use `external-secrets.io/v1` for `ClusterSecretStore`.
* Modified the test configuration in `tests/awssm-cluster-secret-store_test.yaml` to expect the new API version for `ClusterSecretStore`.