### PR TITLE
Bump appVersion in Chart.yaml from 0.17.0 to 0.18.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: &appVersion 0.17.0
+appVersion: &appVersion 0.18.2
 name: &name external-secrets
 version: 1.0.0
 dependencies:


### PR DESCRIPTION
This pull request updates the application version in the Helm chart to reflect the latest release.

* Updated the `appVersion` in `Chart.yaml` from `0.17.0` to `0.18.2` to ensure deployments use the newest application version.

How to test: check out this branch and run workflows with act.